### PR TITLE
Updated index.rst — Added a line on where the documentation is hosted

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,8 @@ and offers a *simple* and *intuitive* API.
 Check out the :doc:`usage` section for further information, including
 how to :ref:`installation` the project.
 
+Lumache has its documentation hosted on Read the Docs.
+
 .. note::
 
    This project is under active development.


### PR DESCRIPTION
Added the following line to index.rst, following the Read the Docs tutorial:

> Lumache has its documentation hosted on Read the Docs.

