### PR TITLE
Update .readthedocs.yaml — set sphinx.fail_on_warning to true

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 
 build:
   os: "ubuntu-22.04"
@@ -11,3 +11,4 @@ python:
 
 sphinx:
   configuration: docs/source/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
Added the sphinx.fail_on_warning line for testing from the Read the Docs tutorial