### PR TITLE
Update .readthedocs.yaml — set sphinx.fail_on_warning to true

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,4 @@ python:
 
 sphinx:
   configuration: docs/source/conf.py
+  fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,9 @@ build:
 python:
   install:
     - requirements: docs/requirements.txt
+    # Install our python package before building the docs
+    - method: pip
+      path: .
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
Set `sphinx.fail_on_warning` to `true` following the Read the Docs tutorial